### PR TITLE
Ambient const enums are not allowed when the '--isolatedModules' flag is provided

### DIFF
--- a/src/FBX.ts
+++ b/src/FBX.ts
@@ -2,7 +2,7 @@ import { FBXData, FBXReader, FBXReaderNode } from 'fbx-parser'
 
 //https://help.autodesk.com/view/FBX/2015/ENU/
 
-export const enum FBXAxes {
+export enum FBXAxes {
   X = 0,
   Y = 1,
   Z = 2,


### PR DESCRIPTION
See e.g.
https://github.com/OfficeDev/microsoft-teams-library-js/pull/387/files
https://github.com/microsoft/fluentui/issues/7110
https://github.com/OfficeDev/microsoft-teams-library-js/issues/267